### PR TITLE
Allow users to provide arbitrary tls.Config for WebClient

### DIFF
--- a/icinga2/icinga.go
+++ b/icinga2/icinga.go
@@ -2,7 +2,6 @@ package icinga2
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"gopkg.in/jmcvetta/napping.v3"
 	"net/http"
@@ -41,10 +40,9 @@ type WebClient struct {
 	Username          string
 	Password          string
 	Debug             bool
-	InsecureTLS       bool
 	DisableKeepAlives bool
 	Zone              string
-	RootCAs           *x509.CertPool
+	TLSConfig         *tls.Config
 }
 
 type MockClient struct {
@@ -69,16 +67,10 @@ type Object interface {
 }
 
 func New(s WebClient) (*WebClient, error) {
-	rootCAs := s.RootCAs
-	if rootCAs == nil {
-		rootCAs, _ = x509.SystemCertPool()
-	}
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: s.InsecureTLS,
-			RootCAs:            rootCAs,
-		},
+		TLSClientConfig:   s.TLSConfig,
 		DisableKeepAlives: s.DisableKeepAlives,
+		ForceAttemptHTTP2: true,
 	}
 	client := &http.Client{Transport: transport}
 


### PR DESCRIPTION
This commit replaces the previous WebClient options `InsecureTLS` and `RootCAs` with a new option `TLSConfig` which can be used to pass an arbitrary tls.Config object which is configured in the WebClient `http.Transport`.

If the TLSConfig option is `nil`, Go's default configuration is used.

We set `ForceAttemptHTTP2` on the `http.Transport` object to true to ensure the HTTP/2 upgrade is attempted even when a custom TLS configuration is passed.

This change allows users of go-icinga2-client to configure the TLS connection by directly providing a tls.Config which contains all the configuration they require.