### PR TITLE
Correctly marshal query filter to JSON

### DIFF
--- a/icinga2/icinga.go
+++ b/icinga2/icinga.go
@@ -11,7 +11,7 @@ import (
 )
 
 type QueryFilter struct {
-	Filter string
+	Filter string `json:"filter"`
 }
 
 type Client interface {


### PR DESCRIPTION
Without an explicit `json` tag, json.Marshal() will export the struct as

```
{ "Filter": "..." }
```

However, Icinga2 requires the key to be all lower-case.

This commit adds the `json:"filter"` tag to the field in the struct to instruct `json.Marshal()` to emit `{ "filter": "..." }`.

See vshn/signalilo#63 for the original bug report.